### PR TITLE
Add request serialization via 429 + consumer retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ bt-servant-worker processes chat requests **one at a time per user** to ensure c
 
 ### How It Works
 
-Each user's chat session is handled by a dedicated Durable Object instance. When a request arrives:
+Each user's chat session is handled by a dedicated Durable Object instance. When a request arrives at `/chat` or `/stream`:
 
 1. The DO checks if another request is currently processing (via a storage lock)
 2. If **not locked**: acquire lock, process request, release lock
@@ -89,7 +89,11 @@ Each user's chat session is handled by a dedicated Durable Object instance. When
 API consumers **must** implement retry logic for 429 responses:
 
 ```typescript
-async function sendChatRequest(message: string, userId: string): Promise<ChatResponse> {
+async function sendChatRequest(
+  message: string,
+  userId: string,
+  org: string
+): Promise<ChatResponse> {
   const maxRetries = 10;
   const baseDelay = 2000; // Start with 2 second delay
 
@@ -129,7 +133,7 @@ async function sendChatRequest(message: string, userId: string): Promise<ChatRes
 ```json
 {
   "error": "Request in progress",
-  "code": "CONCURRENT_REQUEST",
+  "code": "CONCURRENT_REQUEST_REJECTED",
   "message": "Another request for this user is currently being processed. Please retry.",
   "retry_after_ms": 5000
 }

--- a/src/types/engine.ts
+++ b/src/types/engine.ts
@@ -168,11 +168,32 @@ export interface ProgressCallback {
 }
 
 /**
+ * Standard error response format used across all error responses
+ */
+export interface ApiError {
+  error: string;
+  code: string;
+  message: string;
+}
+
+/**
  * Error response when a concurrent request is rejected (429)
  */
-export interface ConcurrentRequestError {
-  error: string;
-  code: 'CONCURRENT_REQUEST';
-  message: string;
+export interface ConcurrentRequestError extends ApiError {
+  code: 'CONCURRENT_REQUEST_REJECTED';
   retry_after_ms: number;
+}
+
+/**
+ * Validation error response (400)
+ */
+export interface ValidationErrorResponse extends ApiError {
+  code: 'VALIDATION_ERROR';
+}
+
+/**
+ * Internal error response (500)
+ */
+export interface InternalErrorResponse extends ApiError {
+  code: 'INTERNAL_ERROR';
 }


### PR DESCRIPTION
## Summary

- Implements per-user request locking in UserSession DO to prevent race conditions in conversation history
- When a user's request is already being processed, subsequent requests receive `429 Too Many Requests` with retry guidance
- Adds storage-based lock mechanism with 5-minute stale threshold for crash recovery
- Documents concurrency model and consumer retry requirements in README

## Changes

| File | Description |
|------|-------------|
| `src/durable-objects/user-session.ts` | Add lock mechanism, modify fetch() to return 429 when locked |
| `src/types/engine.ts` | Add `ConcurrentRequestError` type |
| `tests/e2e/user-session.test.ts` | Add tests for lock behavior |
| `README.md` | Add Request Serialization & Concurrency documentation section |

## Test plan

- [x] Existing tests pass
- [x] New tests verify lock release after request completes
- [x] New tests verify non-chat endpoints don't require lock
- [ ] Manual testing: Send concurrent requests to same user, verify second gets 429

## Consumer follow-up

This PR only implements the bt-servant-worker side. Separate PRs needed for:
- bt-servant-whatsapp-gateway - Add 429 retry logic
- bt-servant-web-client - Add 429 retry logic (and optionally disable send button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)