### PR TITLE
Fix MCP tool call errors from hardcoded wrong parameter example

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,25 +23,25 @@
     "@cf-wasm/quickjs": "^0.2.4",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "hono": "^4.11.7",
-    "zod": "^3.24.0"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.12.8",
-    "@cloudflare/workers-types": "^4.20241230.0",
-    "@eslint/js": "^9.18.0",
-    "@types/node": "^22.10.0",
-    "dependency-cruiser": "^16.0.0",
-    "eslint": "^9.18.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-security": "^3.0.0",
-    "globals": "^15.14.0",
+    "@cloudflare/workers-types": "^4.20260129.0",
+    "@eslint/js": "^9.39.2",
+    "@types/node": "^22.19.7",
+    "dependency-cruiser": "^16.10.4",
+    "eslint": "^9.39.2",
+    "eslint-config-prettier": "^9.1.2",
+    "eslint-plugin-security": "^3.0.1",
+    "globals": "^15.15.0",
     "husky": "^9.1.7",
-    "lint-staged": "^15.3.0",
-    "prettier": "^3.4.0",
-    "typescript": "^5.7.0",
-    "typescript-eslint": "^8.20.0",
-    "vitest": "^2.1.0",
-    "wrangler": "^3.100.0"
+    "lint-staged": "^15.5.2",
+    "prettier": "^3.8.1",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.54.0",
+    "vitest": "^2.1.9",
+    "wrangler": "^3.114.17"
   },
   "lint-staged": {
     "*.{js,mjs,cjs,ts}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,56 +21,56 @@ importers:
         specifier: ^4.11.7
         version: 4.11.7
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.12.8
         version: 0.12.8(@cloudflare/workers-types@4.20260129.0)(@vitest/runner@2.1.9)(@vitest/snapshot@2.1.9)(vitest@2.1.9(@types/node@22.19.7))
       '@cloudflare/workers-types':
-        specifier: ^4.20241230.0
+        specifier: ^4.20260129.0
         version: 4.20260129.0
       '@eslint/js':
-        specifier: ^9.18.0
+        specifier: ^9.39.2
         version: 9.39.2
       '@types/node':
-        specifier: ^22.10.0
+        specifier: ^22.19.7
         version: 22.19.7
       dependency-cruiser:
-        specifier: ^16.0.0
+        specifier: ^16.10.4
         version: 16.10.4
       eslint:
-        specifier: ^9.18.0
+        specifier: ^9.39.2
         version: 9.39.2
       eslint-config-prettier:
-        specifier: ^9.1.0
+        specifier: ^9.1.2
         version: 9.1.2(eslint@9.39.2)
       eslint-plugin-security:
-        specifier: ^3.0.0
+        specifier: ^3.0.1
         version: 3.0.1
       globals:
-        specifier: ^15.14.0
+        specifier: ^15.15.0
         version: 15.15.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^15.3.0
+        specifier: ^15.5.2
         version: 15.5.2
       prettier:
-        specifier: ^3.4.0
+        specifier: ^3.8.1
         version: 3.8.1
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
-        specifier: ^8.20.0
+        specifier: ^8.54.0
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
       vitest:
-        specifier: ^2.1.0
+        specifier: ^2.1.9
         version: 2.1.9(@types/node@22.19.7)
       wrangler:
-        specifier: ^3.100.0
+        specifier: ^3.114.17
         version: 3.114.17(@cloudflare/workers-types@4.20260129.0)
 
 packages:
@@ -1248,8 +1248,8 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-escapes@7.2.0:
     resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
@@ -2100,8 +2100,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
   quickjs-emscripten-core@0.31.0:
@@ -3136,8 +3136,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -3410,9 +3410,9 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
   ajv@6.12.6:
     dependencies:
@@ -3421,7 +3421,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.17.1:
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -3460,7 +3460,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.0
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -3589,7 +3589,7 @@ snapshots:
       acorn-jsx-walk: 2.0.0
       acorn-loose: 8.5.2
       acorn-walk: 8.3.4
-      ajv: 8.17.1
+      ajv: 8.18.0
       commander: 13.1.0
       enhanced-resolve: 5.18.4
       ignore: 7.0.5
@@ -3857,7 +3857,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.0
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -4313,7 +4313,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.1:
+  qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 

--- a/src/services/mcp/catalog.ts
+++ b/src/services/mcp/catalog.ts
@@ -132,18 +132,5 @@ Before using a tool, call \`get_tool_definitions\` with the tool name(s) to get 
 
 | Tool | Description |
 |------|-------------|
-${rows.join('\n')}
-
-### How to use MCP tools:
-1. Review the catalog above to identify relevant tools
-2. Call \`get_tool_definitions\` with the tool names you need
-3. Use the tools in \`execute_code\` based on the returned schemas
-
-Example:
-\`\`\`javascript
-// First call get_tool_definitions to learn the schema
-// Then use the tool in execute_code:
-const result = await fetch_scripture({ book: "John", chapter: 3, verse: 16 });
-__result__ = result;
-\`\`\``;
+${rows.join('\n')}`;
 }

--- a/src/types/prompt-overrides.ts
+++ b/src/types/prompt-overrides.ts
@@ -54,19 +54,11 @@ Help the user understand God's word better. Make the user a better translator.`,
 
   tool_guidance: `## How to Use Tools
 
-You have access to MCP tools for Bible translation data. To use them:
+You have access to MCP tools. To use them:
 
 1. **Review the catalog below** to identify which tools you need
 2. **Call get_tool_definitions** with the tool names to get their full schemas
-3. **Use execute_code** to call the tools with the correct parameters
-
-Example workflow:
-\`\`\`
-// 1. First, call get_tool_definitions to learn the schema
-// 2. Then use execute_code:
-const scripture = await fetch_scripture({ book: "John", chapter: 3, verse: 16 });
-__result__ = scripture;
-\`\`\``,
+3. **Use execute_code** to call the tools with the correct parameters from the schema`,
 
   instructions: `## Resource Usage Guidelines
 


### PR DESCRIPTION
## Summary

- **Remove hardcoded example** from `generateToolCatalog()` that showed `{ book, chapter, verse }` params — the MCP server expects `{ reference }`. Claude was mimicking the wrong example, causing widespread `Missing required parameter: reference` errors.
- **Genericize default `tool_guidance`** so new orgs don't inherit stale domain-specific examples.
- **Update `@modelcontextprotocol/sdk`** 1.25.3 → 1.26.0 and resolve patched transitive deps (ajv 8.17.1 → 8.18.0, qs 6.14.1 → 6.15.0) to fix audit vulnerabilities that were blocking commits.

## Context

The `tool_guidance` prompt override for the `unfoldingWord` org already uses the correct `{ reference }` syntax. But `catalog.ts:generateToolCatalog()` appended a non-overridable hardcoded example with the wrong params right after it. Claude would see both — the correct override and the wrong catalog example — and sometimes follow the wrong one.

## Test plan

- [x] `pnpm audit --prod` — no vulnerabilities
- [x] `pnpm check` — types pass
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 221 tests pass
- [x] `pnpm build` — builds successfully
- [x] Pre-commit hook passes all checks
- [ ] Monitor logs after deploy for reduction in `Missing required parameter: reference` errors