### PR TITLE
Add webhook callback diagnostic logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@anthropic-ai/sdk": "^0.71.2",
     "@cf-wasm/quickjs": "^0.2.4",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "hono": "^4.12.5",
+    "hono": "^4.12.7",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^1.27.1
         version: 1.27.1(zod@3.25.76)
       hono:
-        specifier: ^4.12.5
-        version: 4.12.5
+        specifier: ^4.12.7
+        version: 4.12.7
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -1712,8 +1712,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.5:
-    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
+  hono@4.12.7:
+    resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -2932,9 +2932,9 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.5)':
+  '@hono/node-server@1.19.11(hono@4.12.7)':
     dependencies:
-      hono: 4.12.5
+      hono: 4.12.7
 
   '@humanfs/core@0.19.1': {}
 
@@ -3139,7 +3139,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.5)
+      '@hono/node-server': 1.19.11(hono@4.12.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3149,7 +3149,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.5
+      hono: 4.12.7
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3979,7 +3979,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.5: {}
+  hono@4.12.7: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/src/services/progress/callback.ts
+++ b/src/services/progress/callback.ts
@@ -78,15 +78,33 @@ export class ProgressCallbackSender {
       timestamp: new Date().toISOString(),
     };
 
+    const hasAudio = 'voice_audio_base64' in payload && !!payload.voice_audio_base64;
+    const textLen = 'text' in payload ? ((payload.text as string)?.length ?? 0) : 0;
+    console.warn(
+      JSON.stringify({
+        event: 'webhook_send',
+        type: payload.type,
+        has_text: textLen > 0,
+        text_length: textLen,
+        has_audio: hasAudio,
+        user_id: this.config.user_id,
+      })
+    );
+
     try {
       const response = await fetch(this.config.url, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Engine-Token': this.config.token,
-        },
+        headers: { 'Content-Type': 'application/json', 'X-Engine-Token': this.config.token },
         body: JSON.stringify(fullPayload),
       });
+      console.warn(
+        JSON.stringify({
+          event: 'webhook_response',
+          type: payload.type,
+          status: response.status,
+          user_id: this.config.user_id,
+        })
+      );
 
       if (!response.ok) {
         console.error('[webhook_failure]', {


### PR DESCRIPTION
## Summary
- Adds structured logging to every webhook callback POST (type, has_text, has_audio, text_length) and HTTP response status
- Bumps hono from 4.12.5 to >=4.12.7 to fix moderate prototype pollution audit vulnerability

## Context
Debugging voice messages from WhatsApp — TTS audio is generated successfully but user receives no response. These logs will show whether callbacks reach the gateway and what payload they carry.

## Test plan
- [x] pnpm check passes
- [x] pnpm test passes
- [x] pnpm lint passes
- [ ] Deploy to staging, send voice message, tail logs to see webhook_send/webhook_response events