### PR TITLE
chore(observability): fan logs to bt-servant-telemetry workers

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,8 @@ compatibility_date = "2024-01-01"
 # Must be a top-level field — TOML scoping makes it part of the previous
 # table if placed after a [section], so keep it above [observability].
 tail_consumers = [
-  { service = "bt-servant-tail" }
+  { service = "bt-servant-tail" },
+  { service = "bt-servant-telemetry-production" }
 ]
 
 [observability]
@@ -92,7 +93,8 @@ deleted_classes = ["UserQueue"]
 [env.staging]
 name = "bt-servant-worker-staging"
 tail_consumers = [
-  { service = "bt-servant-tail-staging" }
+  { service = "bt-servant-tail-staging" },
+  { service = "bt-servant-telemetry-dev" }
 ]
 
 [env.staging.limits]


### PR DESCRIPTION
## Summary

Adds the bt-servant-telemetry workers to both \`tail_consumers\` lists:

- top-level / production: \`bt-servant-telemetry-production\`
- \`[env.staging]\`: \`bt-servant-telemetry-dev\`

Both telemetry workers are already deployed in CF (in the \`unfoldingWord\` account) and have been receiving live tail events since they were wired manually with \`wrangler deploy\`. This commit brings the repo's \`wrangler.toml\` in line with the deployed state so a fresh checkout + redeploy doesn't silently drop telemetry ingest.

## Why now

bt-servant-telemetry is a new observability worker (separate repo: \`bt-servant-telemetry\`) that ingests our structured logs, redacts PII via HMAC-hashing of \`user_id\`, and surfaces aggregate metrics on a public dashboard (\`*.unfoldingword.workers.dev\`).

- Live tail = real-time ingest
- Backfill (a separate one-shot) handles the 7-day historical window from CF Observability

The \`bt-servant-tail\` consumer stays in both lists — it captures non-ok outcomes (CPU/memory exhaustion, isolate eviction) that the producer cannot log from inside its own catch blocks. Telemetry is additive, not a replacement.

## Diff

\`\`\`diff
 tail_consumers = [
-  { service = \"bt-servant-tail\" }
+  { service = \"bt-servant-tail\" },
+  { service = \"bt-servant-telemetry-production\" }
 ]
\`\`\`
And the equivalent under \`[env.staging]\` adding \`bt-servant-telemetry-dev\`.

## Test plan

- [x] Pre-commit hooks (lint/check/architecture/test/build) pass
- [x] \`wrangler deploy --dry-run\` confirms both consumer lists resolve correctly
- [x] CF dashboard already shows the consumers wired (production and staging both deployed)
- [ ] After merge: no redeploy required; this commit just reconciles the repo with reality

## Risk

Minimal. Additive change to an array; existing consumer (\`bt-servant-tail\`) is preserved. If telemetry workers were ever deleted, CF rejects the deploy at validation time, so we'd catch a broken reference immediately rather than silently mis-fanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)