### PR TITLE
Parse OBS-TF list_resources instead of treating it as TH v2

### DIFF
--- a/src/services/mcp/resource-listing.ts
+++ b/src/services/mcp/resource-listing.ts
@@ -214,6 +214,70 @@ export function parseTranslationHelpsV2Listing(text: string, serverId: string): 
   return items;
 }
 
+// ─── obs-5m (OBS Five Movements / OBS-TF MCP) adapter ─────────────────────────
+
+/**
+ * obs-5m's `list_resources` shares a tool name with translation-helps v2 but
+ * returns `{ language, resources: [{ id, type, available, source, description }] }`
+ * — no top-level `available` array. Staging currently classifies that as
+ * `translation-helps v2 listing missing "available" array`, so OBS-TF never
+ * appears in Resource priorities and the 5M coach falls through to classic
+ * OBS TH tools (`get_obs_story` / notes / questions).
+ *
+ * Detected by the presence of `fetch_obs_study_manual` on the same server
+ * (capability-based, same pattern as the other adapters).
+ */
+const OBS_5M_TYPE_MAP: Record<string, string> = {
+  structured: 'bible-stories',
+  pdf: 'media',
+};
+
+function extractObs5mResources(text: string): unknown[] {
+  const start = text.indexOf('{');
+  if (start === -1) {
+    throw new Error('obs-5m listing contained no JSON payload');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.slice(start));
+  } catch {
+    throw new Error('obs-5m listing was not valid JSON');
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('obs-5m listing JSON was not an object');
+  }
+  const resources = (parsed as { resources?: unknown }).resources;
+  if (!Array.isArray(resources)) {
+    throw new Error('obs-5m listing missing "resources" array');
+  }
+  return resources;
+}
+
+function normalizeObs5mItem(raw: unknown, serverId: string): ResourceItem | null {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('obs-5m listing item was not an object');
+  }
+  const item = raw as Record<string, unknown>;
+  if (typeof item.id !== 'string' || typeof item.type !== 'string') {
+    throw new Error('obs-5m listing item missing id/type');
+  }
+  if (item.available === false) return null;
+  const normalized: ResourceItem = {
+    name: item.id,
+    subject: normalizeSubject(item.type, OBS_5M_TYPE_MAP),
+    serverId,
+  };
+  if (typeof item.description === 'string') normalized.label = item.description;
+  if (typeof item.source === 'string') normalized.organization = item.source;
+  return normalized;
+}
+
+export function parseObs5mListing(text: string, serverId: string): ResourceItem[] {
+  return extractObs5mResources(text)
+    .map((raw) => normalizeObs5mItem(raw, serverId))
+    .filter((item): item is ResourceItem => item !== null);
+}
+
 // ─── aquifer adapter ──────────────────────────────────────────────────────────
 
 /**
@@ -373,7 +437,7 @@ export function parseAquiferListing(text: string, serverId: string): ResourceIte
 
 export interface ResourceListingAdapter {
   /** Which adapter matched (for logs). */
-  id: 'translation-helps' | 'translation-helps-v2' | 'aquifer';
+  id: 'translation-helps' | 'translation-helps-v2' | 'obs-5m' | 'aquifer';
   toolName: string;
   buildArgs(language: string): Record<string, unknown>;
   parse(text: string, serverId: string): ResourceItem[];
@@ -404,6 +468,13 @@ const AQUIFER_ADAPTER: ResourceListingAdapter = {
   parse: parseAquiferListing,
 };
 
+const OBS_5M_ADAPTER: ResourceListingAdapter = {
+  id: 'obs-5m',
+  toolName: 'list_resources',
+  buildArgs: (language) => ({ language }),
+  parse: parseObs5mListing,
+};
+
 /**
  * Pick the adapter for a server from its discovered tool manifest. The
  * specific tool name is checked before the generic one; a server exposing
@@ -416,7 +487,12 @@ export function selectListingAdapter(
   // Order matters: a server exposing both list_resources_for_language and
   // list_resources must keep the v1 payload, which carries organization and
   // version that v2 drops.
+  // obs-5m also exposes list_resources, but its payload is not TH v2 — detect
+  // it by the study-manual tool before falling through to the v2 parser.
   if (names.has(TRANSLATION_HELPS_ADAPTER.toolName)) return TRANSLATION_HELPS_ADAPTER;
+  if (names.has('fetch_obs_study_manual') && names.has(OBS_5M_ADAPTER.toolName)) {
+    return OBS_5M_ADAPTER;
+  }
   if (names.has(TRANSLATION_HELPS_V2_ADAPTER.toolName)) return TRANSLATION_HELPS_V2_ADAPTER;
   if (names.has(AQUIFER_ADAPTER.toolName)) return AQUIFER_ADAPTER;
   return undefined;

--- a/tests/fixtures/obs-5m-list-en.txt
+++ b/tests/fixtures/obs-5m-list-en.txt
@@ -1,0 +1,3 @@
+1 resource type(s) for en
+
+{"language":"en","resources":[{"id":"obs-tf","type":"structured","available":true,"source":"door43","description":"OBS + Theological Formation from DCS catalog (subject=OBS Theological Formation, topic=tc-ready)"}],"_meta":{"downstream_api_calls":0,"cache_status":"hit"}}

--- a/tests/fixtures/obs-5m-list-id.txt
+++ b/tests/fixtures/obs-5m-list-id.txt
@@ -1,0 +1,3 @@
+2 resource type(s) for id
+
+{"language":"id","resources":[{"id":"obs-tf","type":"structured","available":true,"source":"door43","description":"OBS + Theological Formation from DCS catalog (subject=OBS Theological Formation, topic=tc-ready)"},{"id":"obs-tf-pdf","type":"pdf","available":true,"source":"self-hosted","description":"Self-hosted Indonesian OBS Five Movements PDFs (R2) — use when you need the file; text is also available via fetch_obs_study_manual"}],"_meta":{"downstream_api_calls":0,"cache_status":"hit"}}

--- a/tests/unit/resource-listing.test.ts
+++ b/tests/unit/resource-listing.test.ts
@@ -15,10 +15,15 @@ import AQUIFER_FIXTURE from '../fixtures/aquifer-list-eng.md?raw';
 import TH_FIXTURE from '../fixtures/translation-helps-list-en.json?raw';
 // @ts-expect-error -- ?raw module resolution is handled by Vite, not tsc
 import TH_V2_FIXTURE from '../fixtures/translation-helps-v2-list-en.txt?raw';
+// @ts-expect-error -- ?raw module resolution is handled by Vite, not tsc
+import OBS_5M_EN_FIXTURE from '../fixtures/obs-5m-list-en.txt?raw';
+// @ts-expect-error -- ?raw module resolution is handled by Vite, not tsc
+import OBS_5M_ID_FIXTURE from '../fixtures/obs-5m-list-id.txt?raw';
 import {
   deriveAquiferOrganization,
   listOrgResources,
   parseAquiferListing,
+  parseObs5mListing,
   parseTranslationHelpsListing,
   parseTranslationHelpsV2Listing,
   selectListingAdapter,
@@ -195,6 +200,46 @@ describe('parseTranslationHelpsV2Listing errors', () => {
   });
 });
 
+describe('parseObs5mListing', () => {
+  it('parses the live English listing into bible-stories', () => {
+    const items = parseObs5mListing(OBS_5M_EN_FIXTURE, 'obs-5m');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      name: 'obs-tf',
+      subject: 'bible-stories',
+      serverId: 'obs-5m',
+      organization: 'door43',
+    });
+    expect(KNOWN_SUBJECTS).toContain(items[0]?.subject);
+  });
+
+  it('maps Indonesian structured + pdf rows', () => {
+    const items = parseObs5mListing(OBS_5M_ID_FIXTURE, 'obs-5m');
+    expect(items.map((i) => i.name)).toEqual(['obs-tf', 'obs-tf-pdf']);
+    expect(items.map((i) => i.subject)).toEqual(['bible-stories', 'media']);
+  });
+
+  it('drops unavailable rows', () => {
+    const text =
+      '{"language":"es","resources":[{"id":"obs-tf","type":"structured","available":false,"source":"none","description":"missing"}]}';
+    expect(parseObs5mListing(text, 'obs-5m')).toEqual([]);
+  });
+});
+
+describe('parseObs5mListing errors', () => {
+  it('throws when the payload has no JSON object', () => {
+    expect(() => parseObs5mListing('1 resource type(s) for zz', 'obs-5m')).toThrow(
+      /no JSON payload/
+    );
+  });
+
+  it('throws when resources is missing', () => {
+    expect(() => parseObs5mListing('{"language":"en"}', 'obs-5m')).toThrow(
+      /missing "resources" array/
+    );
+  });
+});
+
 describe('parseAquiferListing', () => {
   it('parses all 35 entries of the live fixture', () => {
     const items = parseAquiferListing(AQUIFER_FIXTURE, 'aquifer');
@@ -305,6 +350,12 @@ describe('selectListingAdapter', () => {
   it('picks translation-helps-v2 for a list_resources tool', () => {
     expect(selectListingAdapter([tool('list_resources'), tool('get_passage')])?.id).toBe(
       'translation-helps-v2'
+    );
+  });
+
+  it('picks obs-5m when list_resources is paired with fetch_obs_study_manual', () => {
+    expect(selectListingAdapter([tool('list_resources'), tool('fetch_obs_study_manual')])?.id).toBe(
+      'obs-5m'
     );
   });
 


### PR DESCRIPTION
## Summary
- Staging reports `OBS Five Movements (obs-5m) failed to respond` because the worker runs the translation-helps v2 parser on every `list_resources` tool. obs-5m-mcp returns `{ resources: [{ id, type, available }] }`, not `{ available: [{ abbreviation, subject }] }`.
- Add an `obs-5m` listing adapter, selected when the server also exposes `fetch_obs_study_manual`, and parse live EN/ID fixtures.
- Unblocks Resource priorities ranking for OBS-TF so the 5M OBS coach can prefer that server instead of falling through to Translation Helps `get_obs_story` / `get_obs_notes` / `get_obs_questions` ([obs-5m-mcp#1](https://github.com/unfoldingWord/obs-5m-mcp/issues/1)).

## Test plan
- [ ] `pnpm test -- tests/unit/resource-listing.test.ts` (Node 22)
- [ ] After deploy to staging: Admin → Modes → 5 Movement OBS Translation → Resource priorities → Load `en`. `obs-5m` should be `ok`, not `translation-helps v2 listing missing "available" array`.
- [ ] Rank `obs-tf` first and confirm a new 5M OBS session calls `fetch_obs_study_manual` for Story 1 intro.


Made with [Cursor](https://cursor.com)